### PR TITLE
Fix implementation of getTZoffset()

### DIFF
--- a/modules/cbi18n/models/i18n.cfc
+++ b/modules/cbi18n/models/i18n.cfc
@@ -686,13 +686,13 @@ www.ortussolutions.com
 	<!--- ************************************************************* --->
 
 	<!--- ************************************************************* --->
-	<cffunction name="getTZOffset" output="false" access="public" hint="returns offset in hours">
+	<cffunction name="getTZOffset" output="false" access="public" hint="returns the offset in hours for the given datetime in the specified timezone">
 		<!--- ************************************************************* --->
-		<cfargument name="thisOffset" required="yes" type="numeric">
+		<cfargument name="thisDate" required="yes" type="date">
 		<cfargument name="thisTZ" required="no" default="#instance.timeZone.getDefault().getID()#">
 		<!--- ************************************************************* --->
 	       <cfset var tZ=instance.timeZone.getTimeZone(arguments.thisTZ)>
-	       <cfreturn tZ.getOffset(arguments.thisOffset)/3600000> <!--- return hours --->
+	       <cfreturn tZ.getOffset(arguments.thisDate)/3600000> <!--- return hours --->
 	</cffunction>
 	<!--- ************************************************************* --->
 


### PR DESCRIPTION
`getTZoffset()` now takes a required argument `thisDate`, which is the datetime (in the server default TZ or optionally specified `thisTZ`) for which the offset will be calculated, additionally taking into account whether DST is applicable at that date.